### PR TITLE
fix(quantumult-x): 修复Speedtest策略组名称

### DIFF
--- a/Quantumult/X/Filter/Speedtest.list
+++ b/Quantumult/X/Filter/Speedtest.list
@@ -1,3 +1,3 @@
 # > Speedtest by Ookla
-USER-AGENT,SpeedTest*,SpeedTest
-DOMAIN-KEYWORD,speedtest,SpeedTest
+USER-AGENT,SpeedTest*,Speedtest
+DOMAIN-KEYWORD,speedtest,Speedtest


### PR DESCRIPTION
Speedtest为一个专用名词不需要驼峰形式，且对应的Zure图库无法识别