### PR TITLE
PlexMediaServer的外网映射问题

### DIFF
--- a/Clash/Pro.yaml
+++ b/Clash/Pro.yaml
@@ -1557,7 +1557,6 @@ Rule:
 - DOMAIN-SUFFIX,worldscientific.com,DIRECT
 # > Plex Media Server
 - DOMAIN-SUFFIX,plex.tv,DIRECT
-- DOMAIN-SUFFIX,ip.sb,DIRECT
 # > Other
 - DOMAIN-SUFFIX,cn,DIRECT
 - DOMAIN-SUFFIX,360in.com,DIRECT

--- a/Clash/Pro.yaml
+++ b/Clash/Pro.yaml
@@ -1555,6 +1555,9 @@ Rule:
 - DOMAIN-SUFFIX,wiley.com,DIRECT
 - DOMAIN-SUFFIX,worldbank.org,DIRECT
 - DOMAIN-SUFFIX,worldscientific.com,DIRECT
+# > Plex Media Server
+- DOMAIN-SUFFIX,plex.tv,DIRECT
+- DOMAIN-SUFFIX,ip.sb,DIRECT
 # > Other
 - DOMAIN-SUFFIX,cn,DIRECT
 - DOMAIN-SUFFIX,360in.com,DIRECT


### PR DESCRIPTION
解决家用PlexMediaServer的在进行外网映射时，误将代理服务器的公网IP作为外网IP使用。